### PR TITLE
Remove jqueryui from require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,5 @@
     "require": {
         "php": ">=5.3.0",
         "roundcube/plugin-installer": ">=0.1.3",
-        "roundcube/jqueryui": ">=0.1"
     }
 }


### PR DESCRIPTION
Jqueryui is included in the current version of roundcube.